### PR TITLE
Add watch-based auto-cleanup and backlog warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,23 @@ OMDB_TIMEOUT_SECONDS=5
 # Legacy alias for DAILY_TV_SERIES_QUOTA — still accepted for backwards compatibility.
 # DAILY_TV_SEASON_QUOTA=1
 
+# --- Watch-Based Auto-Cleanup ---
+# Set CLEANUP_ENABLED=true to activate the cleanup service container.
+#
+# Policy:
+#   - Content is checked every CLEANUP_CHECK_INTERVAL_DAYS days.
+#   - If only the requester has watched it → deleted after the first interval.
+#   - Hard delete after CLEANUP_MAX_AGE_DAYS regardless of who watched.
+#   - Users see a backlog warning when requesting new content if they have
+#     items older than CLEANUP_BACKLOG_WARN_DAYS that they haven't watched.
+#
+# CLEANUP_ENABLED=false
+# CLEANUP_CHECK_INTERVAL_DAYS=7
+# CLEANUP_MAX_AGE_DAYS=28
+# CLEANUP_SCHEDULE_HOUR=3
+# CLEANUP_BACKLOG_WARN_DAYS=3
+# CLEANUP_MIN_WATCHED_EPISODES=1
+
 # --- Data Directory ---
 # Optional: override the directory used for SQLite databases and bug reports.
 # Docker compose files set this automatically (/app/data or /app/data-dev).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build and publish Docker image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -57,3 +57,11 @@ jobs:
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version_no_v }}
             ${{ steps.meta.outputs.image }}:latest
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.version }}
+          name: ${{ steps.meta.outputs.version }}
+          generate_release_notes: true
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ At minimum you need to set:
 | `CONVERSATION_MEMORY_PURGE_ON_LOGOUT` | Delete browser-session conversation history when the user logs out |
 | `ENABLE_REQUESTER_TAGGING` | Set to `true` to add a per-request sanitized username tag to new requests |
 | `REQUESTER_TAG_PREFIX` | Optional prefix prepended to requester tags (for example `req-`) |
+| `CLEANUP_ENABLED` | Set to `true` to activate watch-based auto-cleanup (default `false`) |
+| `CLEANUP_CHECK_INTERVAL_DAYS` | Days between cleanup re-checks per item (default `7`) |
+| `CLEANUP_MAX_AGE_DAYS` | Hard-delete content after this many days regardless of watch status (default `28`) |
+| `CLEANUP_SCHEDULE_HOUR` | UTC hour the cleanup job runs daily (default `3`) |
+| `CLEANUP_BACKLOG_WARN_DAYS` | Warn at download time if the user has unwatched items older than this (default `3`) |
+| `CLEANUP_MIN_WATCHED_EPISODES` | Minimum episodes watched in a season to count as "watched" (default `1`) |
 
 Useful optional defaults for automated media adds:
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,320 @@
+"""Watch-based media cleanup tracking.
+
+Tracks every season/movie added via Media Bot so a periodic cleanup job can
+later check Tautulli watch history and delete content that has gone unwatched
+beyond the configured window.
+
+Two tables are maintained in cleanup.db:
+
+``cleanup_tracking``
+    One row per tracked item (a movie or a specific TV season).  The
+    ``status`` column can be:
+
+    - ``pending``   — actively monitoring; cleanup job will re-check.
+    - ``deleted``   — files and arr record have been removed.
+    - ``protected`` — manually excluded from cleanup.
+
+``deletion_notifications``
+    Short messages queued for delivery to a user the next time they chat.
+    Cleared when ``mark_notifications_delivered`` is called.
+
+Usage::
+
+    from cleanup import CleanupDB
+
+    db = CleanupDB()
+    db.record_addition(
+        media_type="movie",
+        arr_id=42,
+        title="Inception",
+        requester_username="alice",
+        requester_plex_id="123",
+    )
+"""
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import config
+
+log = logging.getLogger(__name__)
+
+_DB_PATH = Path(config.DATA_DIR) / "cleanup.db"
+
+
+def _get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH), timeout=20.0)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS cleanup_tracking (
+            id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+            media_type            TEXT    NOT NULL,
+            arr_id                INTEGER NOT NULL,
+            title                 TEXT    NOT NULL,
+            requester_username    TEXT    NOT NULL,
+            requester_plex_id     TEXT    NOT NULL,
+            season_number         INTEGER,
+            added_date            TEXT    NOT NULL,
+            last_check_date       TEXT,
+            check_count           INTEGER NOT NULL DEFAULT 0,
+            status                TEXT    NOT NULL DEFAULT 'pending',
+            notified              INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_ct_status
+            ON cleanup_tracking (status, added_date);
+
+        CREATE INDEX IF NOT EXISTS idx_ct_requester
+            ON cleanup_tracking (requester_plex_id, status);
+
+        CREATE TABLE IF NOT EXISTS deletion_notifications (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            plex_user_id    TEXT    NOT NULL,
+            message         TEXT    NOT NULL,
+            created_at      TEXT    NOT NULL,
+            delivered       INTEGER NOT NULL DEFAULT 0
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_dn_user_delivered
+            ON deletion_notifications (plex_user_id, delivered);
+    """)
+    conn.commit()
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class CleanupDB:
+    """Thin wrapper around the cleanup SQLite database."""
+
+    def __init__(self) -> None:
+        conn = _get_connection()
+        try:
+            _init_db(conn)
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Write helpers
+    # ------------------------------------------------------------------
+
+    def record_addition(
+        self,
+        *,
+        media_type: str,
+        arr_id: int,
+        title: str,
+        requester_username: str,
+        requester_plex_id: str,
+        season_number: int | None = None,
+    ) -> None:
+        """Record a newly added movie or TV season for future cleanup checks."""
+        if not config.CLEANUP_ENABLED:
+            return
+        if media_type not in ("movie", "series_season"):
+            log.warning("cleanup.record_addition: unknown media_type %r", media_type)
+            return
+
+        conn = _get_connection()
+        try:
+            if media_type == "movie":
+                exists = conn.execute(
+                    "SELECT id FROM cleanup_tracking WHERE arr_id=? AND media_type='movie' AND status='pending'",
+                    (arr_id,),
+                ).fetchone()
+            else:
+                exists = conn.execute(
+                    "SELECT id FROM cleanup_tracking WHERE arr_id=? AND season_number=? AND media_type='series_season' AND status='pending'",
+                    (arr_id, season_number),
+                ).fetchone()
+
+            if exists:
+                return
+
+            conn.execute(
+                """
+                INSERT INTO cleanup_tracking
+                (media_type, arr_id, title, requester_username, requester_plex_id, season_number, added_date)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    media_type,
+                    arr_id,
+                    title,
+                    requester_username,
+                    requester_plex_id,
+                    season_number,
+                    _today_utc(),
+                ),
+            )
+            conn.commit()
+            log.info("cleanup.tracked_addition type=%s title=%r requester=%s", media_type, title, requester_username)
+        finally:
+            conn.close()
+
+    def mark_checked(self, row_id: int) -> None:
+        """Update last_check_date and increment check_count for a row."""
+        conn = _get_connection()
+        try:
+            conn.execute(
+                "UPDATE cleanup_tracking SET last_check_date=?, check_count=check_count+1 WHERE id=?",
+                (_today_utc(), row_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_deleted(self, row_id: int) -> None:
+        """Mark a tracked item as deleted."""
+        conn = _get_connection()
+        try:
+            conn.execute(
+                "UPDATE cleanup_tracking SET status='deleted', last_check_date=? WHERE id=?",
+                (_today_utc(), row_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def mark_protected(self, row_id: int) -> None:
+        """Exclude a tracked item from future cleanup checks."""
+        conn = _get_connection()
+        try:
+            conn.execute(
+                "UPDATE cleanup_tracking SET status='protected' WHERE id=?",
+                (row_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Read helpers
+    # ------------------------------------------------------------------
+
+    def get_pending_checks(self) -> list[dict]:
+        """Return all items that are due for a cleanup pass.
+        
+        Only returns items where it has been at least 1 day since the
+        previous check or the last check was at least
+        ``CLEANUP_CHECK_INTERVAL_DAYS`` ago.
+        """
+        interval = max(1, config.CLEANUP_CHECK_INTERVAL_DAYS)
+        conn = _get_connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT * FROM cleanup_tracking
+                WHERE status = 'pending'
+                  AND (
+                      last_check_date IS NULL
+                      OR cast(julianday(?) - julianday(last_check_date) as integer) >= ?
+                  )
+                ORDER BY added_date ASC
+                """,
+                (_today_utc(), interval),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def get_all_pending_for_user(self, plex_user_id: str) -> list[dict]:
+        """Return all pending rows for a given Plex user ID."""
+        conn = _get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM cleanup_tracking WHERE requester_plex_id=? AND status='pending' ORDER BY added_date ASC",
+                (plex_user_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def get_pending_series_seasons(self, arr_id: int) -> list[dict]:
+        """Return all pending season rows for a series arr_id."""
+        conn = _get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM cleanup_tracking WHERE arr_id=? AND media_type='series_season' AND status='pending'",
+                (arr_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Deletion notifications for the user
+    # ------------------------------------------------------------------
+
+    def queue_deletion_notification(self, plex_user_id: str, message: str) -> None:
+        """Store a deletion notice for delivery on the user's next chat."""
+        conn = _get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO deletion_notifications (plex_user_id, message, created_at) VALUES (?, ?, ?)",
+                (plex_user_id, message, _now_utc()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_undelivered_notifications(self, plex_user_id: str) -> list[dict]:
+        """Return undelivered deletion notices for a user."""
+        conn = _get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT id, message FROM deletion_notifications WHERE plex_user_id=? AND delivered=0 ORDER BY created_at ASC",
+                (plex_user_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def mark_notifications_delivered(self, plex_user_id: str) -> None:
+        """Mark all pending notices for a user as delivered."""
+        conn = _get_connection()
+        try:
+            conn.execute(
+                "UPDATE deletion_notifications SET delivered=1 WHERE plex_user_id=? AND delivered=0",
+                (plex_user_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_unwatched_backlog_titles(self, plex_user_id: str) -> list[str]:
+        """Return titles of completely unwatched content older than warn_days.
+        
+        This is used to quickly inject a warning into the agent response
+        at download time.  Does NOT call Tautulli — that check happens in the
+        cleanup service; this is a fast DB-only look-up.
+        """
+        warn_days = max(1, config.CLEANUP_BACKLOG_WARN_DAYS)
+        conn = _get_connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT title FROM cleanup_tracking
+                WHERE requester_plex_id = ?
+                  AND status = 'pending'
+                  AND cast(julianday(?) - julianday(added_date) as integer) >= ?
+                ORDER BY added_date ASC
+                LIMIT 5
+                """,
+                (plex_user_id, _today_utc(), warn_days),
+            ).fetchall()
+            return [r['title'] for r in rows]
+        finally:
+            conn.close()

--- a/cleanup_service.py
+++ b/cleanup_service.py
@@ -1,0 +1,257 @@
+"""Standalone cleanup service entry point.
+
+Run as a separate container alongside media-bot using the same image::
+
+    command: ["python", "cleanup_service.py"]
+
+The service wakes once per day at ``CLEANUP_SCHEDULE_HOUR`` (UTC) and calls
+``cleanup_pass()`` which:
+
+1. Reads all pending cleanup_tracking rows that are due for a re-check.
+2. Queries Tautulli for watch history across **all** users.
+3. Applies the deletion policy:
+
+   - Age ≥ ``CLEANUP_CHECK_INTERVAL_DAYS`` days **and** only the requester
+     watched it → delete immediately.
+   - Age ≥ ``CLEANUP_MAX_AGE_DAYS`` days → hard-delete regardless of who
+     watched.
+   - Otherwise → skip (re-check on next cycle).
+
+4. Deletions remove files from disk via Radarr/Sonarr and write a
+   ``deletion_notifications`` row so the user sees a notice on their next chat.
+"""
+
+import logging
+import sys
+from datetime import datetime, timezone
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+import config
+import tautulli_usage
+from api.radarr import RadarrAPI
+from api.sonarr import SonarrAPI
+from cleanup import CleanupDB
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=config.LOG_LEVEL,
+    format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+)
+log = logging.getLogger(__name__)
+
+_db = CleanupDB()
+
+
+# ---------------------------------------------------------------------------
+# Policy helpers
+# ---------------------------------------------------------------------------
+
+def _age_days(added_date_str: str) -> int:
+    """Return how many full days have passed since ``added_date_str`` (YYYY-MM-DD)."""
+    try:
+        added = datetime.fromisoformat(added_date_str).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return 0
+    delta = datetime.now(timezone.utc) - added
+    return max(0, delta.days)
+
+
+def _requester_watched(watchers: dict[str, int], requester_username: str) -> bool:
+    """True if the requester has at least CLEANUP_MIN_WATCHED_EPISODES plays."""
+    count = watchers.get(requester_username, 0)
+    return count >= config.CLEANUP_MIN_WATCHED_EPISODES
+
+
+def _others_watched(watchers: dict[str, int], requester_username: str) -> bool:
+    """True if any user *other than* the requester has watched the content."""
+    for uname, count in watchers.items():
+        if uname.lower() != requester_username.lower() and count >= config.CLEANUP_MIN_WATCHED_EPISODES:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Deletion helpers
+# ---------------------------------------------------------------------------
+
+def _delete_movie(arr_id: int, title: str) -> bool:
+    try:
+        radarr = RadarrAPI()
+        ok = radarr.delete_movie(arr_id, delete_files=True)
+        if ok:
+            log.info("cleanup.deleted_movie title=%r arr_id=%s", title, arr_id)
+        else:
+            log.warning("cleanup.delete_movie_failed title=%r arr_id=%s", title, arr_id)
+        return ok
+    except Exception:
+        log.exception("cleanup.delete_movie_error title=%r arr_id=%s", title, arr_id)
+        return False
+
+
+def _delete_series_season(arr_id: int, season_number: int, title: str) -> bool:
+    """Delete episode files for a specific season.  If all tracked seasons for
+    this series are subsequently deleted, remove the series record too."""
+    try:
+        sonarr = SonarrAPI()
+        files = sonarr.get_episode_files(arr_id, season_number=season_number)
+        if files is None:
+            log.warning(
+                "cleanup.get_episode_files_failed title=%r arr_id=%s season=%s",
+                title, arr_id, season_number,
+            )
+            return False
+
+        if files:
+            file_ids = [f['id'] for f in files if isinstance(f, dict) and f.get('id')]
+            if file_ids:
+                ok = sonarr.delete_episode_files_bulk(file_ids)
+                if not ok:
+                    log.warning(
+                        "cleanup.bulk_delete_failed title=%r arr_id=%s season=%s",
+                        title, arr_id, season_number,
+                    )
+                    return False
+
+        # Unmonitor the season to prevent infinite re-download loops
+        sonarr.unmonitor_season(arr_id, season_number)
+
+        log.info(
+            "cleanup.deleted_season title=%r arr_id=%s season=%s files=%s",
+            title, arr_id, season_number, len(files) if files else 0,
+        )
+
+        # Check whether any tracked seasons remain pending; if not, remove the series
+        remaining = _db.get_pending_series_seasons(arr_id)
+        # Filter out the season we just deleted (it hasn't been marked yet)
+        still_tracked = [r for r in remaining if r['season_number'] != season_number]
+        if not still_tracked:
+            sonarr.delete_series(arr_id, delete_files=False)
+            log.info("cleanup.deleted_series title=%r arr_id=%s (all seasons cleaned)", title, arr_id)
+
+        return True
+    except Exception:
+        log.exception(
+            "cleanup.delete_season_error title=%r arr_id=%s season=%s",
+            title, arr_id, season_number,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Core cleanup pass
+# ---------------------------------------------------------------------------
+
+def cleanup_pass() -> None:
+    """Run one full cleanup evaluation cycle."""
+    if not config.CLEANUP_ENABLED:
+        log.debug("cleanup.pass_skipped: CLEANUP_ENABLED=false")
+        return
+
+    log.info("cleanup.pass_start")
+    due_rows = _db.get_pending_checks()
+    log.info("cleanup.pass_rows_due count=%d", len(due_rows))
+
+    for row in due_rows:
+        row_id = row['id']
+        media_type = row['media_type']
+        arr_id = row['arr_id']
+        title = row['title']
+        requester_username = row['requester_username']
+        requester_plex_id = row['requester_plex_id']
+        season_number = row.get('season_number')
+        added_date = row['added_date']
+
+        age = _age_days(added_date)
+        max_age = max(1, config.CLEANUP_MAX_AGE_DAYS)
+        interval = max(1, config.CLEANUP_CHECK_INTERVAL_DAYS)
+
+        # Fetch watch data
+        is_tv = (media_type == 'series_season')
+        try:
+            watchers = tautulli_usage.get_all_watchers_for_title(
+                title,
+                season_number=season_number if is_tv else None,
+                days=max_age + interval,
+            )
+        except Exception:
+            log.exception("cleanup.tautulli_error title=%r — skipping row %s", title, row_id)
+            continue
+
+        requester_watched = _requester_watched(watchers, requester_username)
+        others_watched = _others_watched(watchers, requester_username)
+
+        # ----- Deletion policy -----
+        should_delete = False
+        reason = ""
+
+        if age >= max_age:
+            should_delete = True
+            reason = f"reached max age of {max_age} days"
+        elif age >= interval and requester_watched and not others_watched:
+            should_delete = True
+            reason = f"only requester watched it and content is {age} days old"
+
+        log.debug(
+            "cleanup.evaluated title=%r age=%dd requester_watched=%s others_watched=%s delete=%s",
+            title, age, requester_watched, others_watched, should_delete,
+        )
+
+        if should_delete:
+            if is_tv:
+                ok = _delete_series_season(arr_id, season_number, title)
+            else:
+                ok = _delete_movie(arr_id, title)
+
+            if ok:
+                _db.mark_deleted(row_id)
+                season_str = f" Season {season_number}" if is_tv else ""
+                _db.queue_deletion_notification(
+                    requester_plex_id,
+                    f"\U0001f5d1\ufe0f **{title}{season_str}** has been automatically removed "
+                    f"from the library ({reason}).",
+                )
+        else:
+            _db.mark_checked(row_id)
+
+    log.info("cleanup.pass_end")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    log.info(
+        "cleanup_service starting: schedule=%02d:00 UTC interval=%dd max_age=%dd",
+        config.CLEANUP_SCHEDULE_HOUR,
+        config.CLEANUP_CHECK_INTERVAL_DAYS,
+        config.CLEANUP_MAX_AGE_DAYS,
+    )
+
+    if not config.CLEANUP_ENABLED:
+        log.warning("CLEANUP_ENABLED is false — service will run but cleanup_pass() is a no-op.")
+
+    scheduler = BlockingScheduler(timezone='UTC')
+    scheduler.add_job(
+        cleanup_pass,
+        trigger='cron',
+        hour=config.CLEANUP_SCHEDULE_HOUR,
+        minute=0,
+        id='cleanup_pass',
+        name='Watch-based media cleanup',
+        misfire_grace_time=3600,
+    )
+
+    # Also run once at startup so operators can verify it works on first deploy
+    log.info("cleanup_service: running initial pass at startup")
+    try:
+        cleanup_pass()
+    except Exception:
+        log.exception("cleanup_service: startup pass failed — scheduler will continue")
+
+    log.info("cleanup_service: scheduler started")
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):
+        log.info("cleanup_service: shutting down")

--- a/config.py
+++ b/config.py
@@ -102,6 +102,19 @@ CONVERSATION_MEMORY_CLEANUP_INTERVAL = int(os.getenv("CONVERSATION_MEMORY_CLEANU
 # Purge stored browser-session conversation history on logout.
 CONVERSATION_MEMORY_PURGE_ON_LOGOUT = os.getenv("CONVERSATION_MEMORY_PURGE_ON_LOGOUT", "true").lower() in ("1", "true", "yes")
 
+# Watch-based cleanup
+CLEANUP_ENABLED = os.getenv("CLEANUP_ENABLED", "false").lower() in ("1", "true", "yes")
+# How many days between re-checks for unwatched content (also the first-check window)
+CLEANUP_CHECK_INTERVAL_DAYS = int(os.getenv("CLEANUP_CHECK_INTERVAL_DAYS", "7"))
+# Hard-delete content after this many days regardless of watch status
+CLEANUP_MAX_AGE_DAYS = int(os.getenv("CLEANUP_MAX_AGE_DAYS", "28"))
+# Hour of day (UTC, 0-23) at which the cleanup job runs
+CLEANUP_SCHEDULE_HOUR = int(os.getenv("CLEANUP_SCHEDULE_HOUR", "3"))
+# Warn the user at download time if they have unwatched content older than this many days
+CLEANUP_BACKLOG_WARN_DAYS = int(os.getenv("CLEANUP_BACKLOG_WARN_DAYS", "3"))
+# Minimum distinct episodes watched in a season for it to count as "watched"
+CLEANUP_MIN_WATCHED_EPISODES = int(os.getenv("CLEANUP_MIN_WATCHED_EPISODES", "1"))
+
 # Flask
 FLASK_SECRET_KEY = os.getenv("FLASK_SECRET_KEY")
 if not FLASK_SECRET_KEY or len(FLASK_SECRET_KEY) < 16:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,5 +31,27 @@ services:
       retries: 3
       start_period: 15s
 
+  media-bot-cleanup-dev:
+    build: .
+    container_name: media-bot-cleanup-dev
+    restart: unless-stopped
+    command: ["python", "cleanup_service.py"]
+    env_file:
+      - .env
+    environment:
+      - FLASK_ENV=development
+      - APP_VERSION=dev
+      - DATA_DIR=/app/data-dev
+      - CLEANUP_ENABLED=${CLEANUP_ENABLED:-false}
+      - CLEANUP_CHECK_INTERVAL_DAYS=${CLEANUP_CHECK_INTERVAL_DAYS:-7}
+      - CLEANUP_MAX_AGE_DAYS=${CLEANUP_MAX_AGE_DAYS:-28}
+      - CLEANUP_SCHEDULE_HOUR=${CLEANUP_SCHEDULE_HOUR:-3}
+      - CLEANUP_BACKLOG_WARN_DAYS=${CLEANUP_BACKLOG_WARN_DAYS:-3}
+      - CLEANUP_MIN_WATCHED_EPISODES=${CLEANUP_MIN_WATCHED_EPISODES:-1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - cache-data-dev:/app/data-dev
+
 volumes:
   cache-data-dev:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,5 +24,31 @@ services:
       retries: 3
       start_period: 15s
 
+  media-bot-cleanup:
+    # ⚠️ CRITICAL WARNING: 
+    # Do not deploy this service until a new container image build/release has been cut
+    # that includes the `apscheduler` package. Applying this stack before the image is
+    # updated in GHCR will cause this sidecar container to immediately crash with a ModuleNotFoundError.
+    image: ghcr.io/lachiendupape/media-bot:${MEDIA_BOT_VERSION:-latest}
+    container_name: media-bot-cleanup
+    restart: unless-stopped
+    command: ["python", "cleanup_service.py"]
+    env_file:
+      - .env
+    environment:
+      - FLASK_ENV=production
+      - APP_VERSION=${MEDIA_BOT_VERSION:-latest}
+      - DATA_DIR=/app/data
+      - CLEANUP_ENABLED=${CLEANUP_ENABLED:-false}
+      - CLEANUP_CHECK_INTERVAL_DAYS=${CLEANUP_CHECK_INTERVAL_DAYS:-7}
+      - CLEANUP_MAX_AGE_DAYS=${CLEANUP_MAX_AGE_DAYS:-28}
+      - CLEANUP_SCHEDULE_HOUR=${CLEANUP_SCHEDULE_HOUR:-3}
+      - CLEANUP_BACKLOG_WARN_DAYS=${CLEANUP_BACKLOG_WARN_DAYS:-3}
+      - CLEANUP_MIN_WATCHED_EPISODES=${CLEANUP_MIN_WATCHED_EPISODES:-1}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - cache-data:/app/data
+
 volumes:
   cache-data:

--- a/llm.py
+++ b/llm.py
@@ -10,7 +10,10 @@ from api.sonarr import SonarrAPI
 import config
 import notifications
 import quota
+from cleanup import CleanupDB
 from observability import redact_sensitive_fields, start_span
+
+_cleanup_db = CleanupDB()
 
 log = logging.getLogger(__name__)
 
@@ -447,6 +450,25 @@ def _user_identity(user_info: dict | None) -> tuple[str, str]:
     return 'api_key', 'api_key'
 
 
+def _backlog_warning(user_id: str) -> str | None:
+    """Return a warning message if the user has unwatched content older than
+    CLEANUP_BACKLOG_WARN_DAYS, or None when the feature is disabled or the
+    backlog is empty."""
+    if not config.CLEANUP_ENABLED:
+        return None
+    try:
+        titles = _cleanup_db.get_unwatched_backlog_titles(user_id)
+    except Exception:
+        log.debug("cleanup.backlog_check_error user_id=%r", user_id)
+        return None
+    if not titles:
+        return None
+    if len(titles) == 1:
+        return f"Just a heads-up — you still haven't watched **{titles[0]}** that you added earlier."
+    listed = ", ".join(f"**{t}**" for t in titles[:-1]) + f" and **{titles[-1]}**"
+    return f"Just a heads-up — you haven't watched {listed} yet from your earlier requests."
+
+
 def _requester_tag_from_username(username: str | None) -> str | None:
     """Build a safe requester tag from username when requester tagging is enabled."""
     if not config.ENABLE_REQUESTER_TAGGING:
@@ -504,9 +526,21 @@ def _do_add_radarr_movie(radarr: "RadarrAPI", selected_movie: dict, is_kids: boo
             notifications.record_pending_download(user_id, username, selected_movie['title'], "movie")
         except Exception:
             log.warning("Failed to record pending download notification for movie")
-        return f"Great news! '{selected_movie['title']} ({selected_movie.get('year', '')})' has been grabbed and is downloading now — it'll be with you shortly!"
+        try:
+            arr_id = result.get('id') if isinstance(result, dict) else None
+            if arr_id and config.CLEANUP_ENABLED:
+                _cleanup_db.record_addition(
+                    media_type="movie",
+                    arr_id=arr_id,
+                    title=selected_movie['title'],
+                    requester_username=username,
+                    requester_plex_id=user_id,
+                )
+        except Exception:
+            log.warning("Failed to record cleanup tracking entry for movie")
+        return f"Great news! '{selected_movie['title']} ({selected_movie.get('year', '')})' has been grabbed and is downloading now \u2014 it'll be with you shortly!"
     if error == 'already_exists':
-        return f"'{selected_movie['title']} ({selected_movie.get('year', '')})' is already in your library — no need to add it again!"
+        return f"'{selected_movie['title']} ({selected_movie.get('year', '')})' is already in your library \u2014 no need to add it again!"
     return f"Failed to add movie '{selected_movie['title']}': {error}"
 
 
@@ -526,6 +560,8 @@ def add_radarr_movie_handler(
     allowed, quota_msg = quota.check_quota(user_id, username, "movie")
     if not allowed:
         return quota_msg
+
+    _backlog_warn = _backlog_warning(user_id)
 
     initial_kids_preference = _initial_kids_preference(title, is_kids)
     radarr = RadarrAPI()
@@ -585,7 +621,10 @@ def add_radarr_movie_handler(
         )
 
     final_kids = bool(resolved_kids) if resolved_kids is not None else False
-    return _do_add_radarr_movie(radarr, selected_movie, is_kids=final_kids, user_id=user_id, username=username)
+    result_msg = _do_add_radarr_movie(radarr, selected_movie, is_kids=final_kids, user_id=user_id, username=username)
+    if _backlog_warn and result_msg.startswith("Great news!"):
+        return f"{_backlog_warn}\n\n{result_msg}"
+    return result_msg
 
 def add_sonarr_series_handler(
     title: str,
@@ -604,6 +643,8 @@ def add_sonarr_series_handler(
     allowed, quota_msg = quota.check_quota(user_id, username, "tv_series")
     if not allowed:
         return quota_msg
+
+    _backlog_warn = _backlog_warning(user_id)
 
     initial_kids_preference = _initial_kids_preference(title, is_kids)
     sonarr = SonarrAPI()
@@ -725,7 +766,23 @@ def add_sonarr_series_handler(
             notifications.record_pending_download(user_id, username, selected_series['title'], "tv_season")
         except Exception:
             log.warning("Failed to record pending download notification for series")
-        return f"Great news! '{selected_series['title']}' Season {season} has been grabbed and is downloading now — it'll be with you shortly!"
+        try:
+            arr_id = result.get('id') if isinstance(result, dict) else None
+            if arr_id and config.CLEANUP_ENABLED:
+                _cleanup_db.record_addition(
+                    media_type="series_season",
+                    arr_id=arr_id,
+                    title=selected_series['title'],
+                    requester_username=username,
+                    requester_plex_id=user_id,
+                    season_number=season,
+                )
+        except Exception:
+            log.warning("Failed to record cleanup tracking entry for series")
+        success_msg = f"Great news! '{selected_series['title']}' Season {season} has been grabbed and is downloading now — it'll be with you shortly!"
+        if _backlog_warn:
+            return f"{_backlog_warn}\n\n{success_msg}"
+        return success_msg
     if error == 'already_exists':
         # Series exists in library — check if the requested season is already monitored
         tvdb_id = selected_series.get('tvdbId')
@@ -748,10 +805,25 @@ def add_sonarr_series_handler(
                     notifications.record_pending_download(user_id, username, existing['title'], "tv_season")
                 except Exception:
                     log.warning("Failed to record pending download notification for series")
-                return (
+                try:
+                    if config.CLEANUP_ENABLED:
+                        _cleanup_db.record_addition(
+                            media_type="series_season",
+                            arr_id=existing['id'],
+                            title=existing['title'],
+                            requester_username=username,
+                            requester_plex_id=user_id,
+                            season_number=season,
+                        )
+                except Exception:
+                    log.warning("Failed to record cleanup tracking entry for series (update path)")
+                update_msg = (
                     f"Great news! '{existing['title']}' Season {season} has been grabbed "
                     f"and is downloading now — it'll be with you shortly!"
                 )
+                if _backlog_warn:
+                    return f"{_backlog_warn}\n\n{update_msg}"
+                return update_msg
             return f"Failed to update '{selected_series['title']}': {update_error}"
         return f"'{selected_series['title']} ({selected_series.get('year', '')})' is already in your library — no need to add it again!"
     return f"Failed to add TV series '{selected_series['title']}': {error}"

--- a/llm.py
+++ b/llm.py
@@ -621,8 +621,21 @@ def add_radarr_movie_handler(
         )
 
     final_kids = bool(resolved_kids) if resolved_kids is not None else False
-    result_msg = _do_add_radarr_movie(radarr, selected_movie, is_kids=final_kids, user_id=user_id, username=username)
-    if _backlog_warn and result_msg.startswith("Great news!"):
+    add_result = _do_add_radarr_movie(
+        radarr,
+        selected_movie,
+        is_kids=final_kids,
+        user_id=user_id,
+        username=username,
+    )
+    if isinstance(add_result, tuple) and len(add_result) == 2:
+        add_ok, result_msg = add_result
+    else:
+        # Backward-compatible fallback for legacy string-only returns.
+        result_msg = add_result
+        add_ok = isinstance(result_msg, str) and result_msg.startswith("Great news!")
+
+    if _backlog_warn and add_ok:
         return f"{_backlog_warn}\n\n{result_msg}"
     return result_msg
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,8 @@ import tautulli_usage
 import plex_auth
 import config
 import memory
+from cleanup import CleanupDB
+_cleanup_db = CleanupDB()
 from observability import (
     append_jsonl,
     clear_request_id,
@@ -501,6 +503,17 @@ def chat():
                 notifications.mark_delivered([n['id'] for n in pending])
                 notification_lines = [n['message'] for n in pending]
                 response_text = "\n".join(notification_lines) + "\n\n" + response_text
+
+        # Deliver any pending cleanup (auto-deletion) notices
+        if user_id and config.CLEANUP_ENABLED:
+            try:
+                cleanup_notices = _cleanup_db.get_undelivered_notifications(user_id)
+                if cleanup_notices:
+                    _cleanup_db.mark_notifications_delivered(user_id)
+                    cleanup_lines = [n['message'] for n in cleanup_notices]
+                    response_text = "\n".join(cleanup_lines) + "\n\n" + response_text
+            except Exception:
+                log.warning('cleanup.notification_delivery_error')
 
         session['last_request_id'] = g.request_id
         _remember_request_context(g.request_id, {

--- a/main.py
+++ b/main.py
@@ -513,7 +513,7 @@ def chat():
                     cleanup_lines = [n['message'] for n in cleanup_notices]
                     response_text = "\n".join(cleanup_lines) + "\n\n" + response_text
             except Exception:
-                log.warning('cleanup.notification_delivery_error')
+                log.exception('cleanup.notification_delivery_error')
 
         session['last_request_id'] = g.request_id
         _remember_request_context(g.request_id, {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai>=2.30,<3
 sentry-sdk[flask]>=2.14,<3
 opentelemetry-sdk>=1.28,<2
 opentelemetry-exporter-otlp>=1.28,<2
+apscheduler>=3.10,<4

--- a/tautulli_usage.py
+++ b/tautulli_usage.py
@@ -379,3 +379,101 @@ def build_weekly_usage_message(plex_username: str) -> WelcomeData | None:
     message = _format_weekly_summary(username, history_rows)
     _cache.set(cache_key, message)
     return message
+
+def get_all_watchers_for_title(
+    title: str,
+    *,
+    season_number: int | None = None,
+    days: int = 35,
+) -> dict[str, int]:
+    """Return a mapping of Plex username → watch-count for a given title.
+
+    For movies ``season_number`` should be ``None`` and the match is on the
+    ``title`` field of Tautulli history rows (case-insensitive).
+
+    For TV seasons pass the season number; the match is on
+    ``grandparent_title`` + ``parent_media_index``.  The count represents the
+    number of **distinct episodes** watched per user.
+
+    Returns an empty dict when Tautulli is unavailable or the title has not
+    been watched at all.  Failures are logged but not raised.
+    """
+    if not config.TAUTULLI_URL or not config.TAUTULLI_API_KEY:
+        return {}
+
+    cutoff = int(time.time()) - max(1, days) * 86400
+
+    # Resolve all Tautulli user IDs so we can label results by username.
+    users_data = _call_tautulli('get_users')
+    if not users_data:
+        return {}
+    user_rows = users_data if isinstance(users_data, list) else users_data.get('data', [])
+    id_to_name: dict[str, str] = {}
+    for u in user_rows:
+        if not isinstance(u, dict):
+            continue
+        uid = str(u.get('user_id', '')).strip()
+        uname = str(u.get('friendly_name') or u.get('username') or uid).strip()
+        if uid:
+            id_to_name[uid] = uname
+
+    title_lower = (title or '').strip().lower()
+    is_tv = season_number is not None
+
+    watchers: dict[str, set] = {}
+
+    for uid, uname in id_to_name.items():
+        page_len = 500
+        start_pos = 0
+
+        while True:
+            history = _call_tautulli('get_history', user_id=uid, length=page_len, start=start_pos, start_date=cutoff)
+            if not history:
+                break
+            rows = history if isinstance(history, list) else history.get('data', [])
+            if not isinstance(rows, list) or not rows:
+                break
+
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                try:
+                    watched_at = int(row.get('date') or 0)
+                except (TypeError, ValueError):
+                    watched_at = 0
+                if watched_at < cutoff:
+                    continue
+
+                media_type = str(row.get('media_type', '')).lower()
+
+                if not is_tv:
+                    # Movie: match on title field
+                    if media_type != 'movie':
+                        continue
+                    row_title = str(row.get('title') or '').strip().lower()
+                    if row_title != title_lower:
+                        continue
+                    watchers.setdefault(uname, set()).add('movie')
+                else:
+                    # Episode: match on show title + season number
+                    if media_type != 'episode':
+                        continue
+                    show_name = (
+                        str(row.get('grandparent_title') or '').strip()
+                        or str(row.get('parent_title') or '').strip()
+                        or str(row.get('title') or '').strip()
+                    ).lower()
+                    if show_name != title_lower:
+                        continue
+                    row_season = _to_positive_int(row.get('parent_media_index'))
+                    if row_season != season_number:
+                        continue
+                    ep_num = _to_positive_int(row.get('media_index'))
+                    key = ep_num if ep_num is not None else object()
+                    watchers.setdefault(uname, set()).add(key)
+
+            if len(rows) < page_len:
+                break
+            start_pos += page_len
+
+    return {uname: len(ep_set) for uname, ep_set in watchers.items()}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -282,19 +282,13 @@
     </header>
     <div class="notification-banner" id="notificationBanner" aria-live="polite" aria-label="Download notifications"></div>
     <div class="chat-area" id="chatArea">
-        <div class="msg bot">Hi {{ user.username }}! I’m here to help with your <strong>{{ plex_server_name or 'Plex' }} library</strong>.
+        <div class="msg bot" id="welcomeMsg"><span id="greetingText">Hi</span> {{ user.username }}! I'm here to help with your <strong>{{ plex_server_name or 'Plex' }} library</strong>.
 
 {% if usage_summary %}{{ usage_summary }}
 
 {% endif %}
 
-You can ask me to find cast or directors, add movies or TV, clean up media if you’re the owner, or suggest something similar to a title you already have.
-
-I can also switch up how I reply. Try something like "speak like a pirate" or "reset style".
-
-If you want the full list, just say <strong>help</strong> or <strong>what can you do</strong>.
-
-I’m only working with your own library and connected services, not the wider internet.</div>{% if next_season_suggestions %}
+Ask me to add movies or TV, check downloads, look up cast and directors, or find similar titles. Say <strong>help</strong> for the full list.{% if next_season_suggestions %} I've also spotted a few shows you might want to continue — quick-add buttons are below.{% endif %}</div>{% if next_season_suggestions %}
         <div class="quick-action-row">
 {% for s in next_season_suggestions %}
           <button class="quick-action-btn" onclick="sendMessage('Add {{ s.show }} Season {{ s.next_season }}')" type="button">▶ Queue {{ s.show }} Season {{ s.next_season }}</button>
@@ -328,6 +322,16 @@ I’m only working with your own library and connected services, not the wider i
         </div>
     </div>
     <script>
+        // Personalise the welcome greeting based on time of day and Tautulli data
+        (function() {
+            const greetingEl = document.getElementById('greetingText');
+            if (!greetingEl) return;
+            const hour = new Date().getHours();
+            const timeGreeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening';
+            const hasUsage = {{ 'true' if usage_summary else 'false' }};
+            greetingEl.textContent = hasUsage ? timeGreeting + ', welcome back' : timeGreeting;
+        })();
+
         const chatArea = document.getElementById('chatArea');
         const input = document.getElementById('msgInput');
         const btn = document.getElementById('sendBtn');

--- a/tests/test_tautulli_usage.py
+++ b/tests/test_tautulli_usage.py
@@ -130,3 +130,364 @@ def test_phase2_skips_suggestion_when_next_season_missing(monkeypatch):
     assert message is not None
     assert 'Up next:' not in message.text
     assert message.suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# get_all_watchers_for_title tests
+# ---------------------------------------------------------------------------
+
+def _make_users_response(users):
+    """Return a fake get_users Tautulli response list."""
+    return users
+
+
+def _make_history_response(rows):
+    """Return a fake get_history Tautulli response dict."""
+    return {'data': rows}
+
+
+def test_get_all_watchers_returns_empty_when_tautulli_unconfigured(monkeypatch):
+    """Returns {} immediately when TAUTULLI_URL or TAUTULLI_API_KEY is missing."""
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', '')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune')
+    assert result == {}
+
+
+def test_get_all_watchers_returns_empty_when_api_key_missing(monkeypatch):
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', '')
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune')
+    assert result == {}
+
+
+def test_get_all_watchers_movie_match(monkeypatch):
+    """Counts a movie watch for the matching user; excludes non-matching titles."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [
+        {'user_id': '1', 'friendly_name': 'alice'},
+        {'user_id': '2', 'friendly_name': 'bob'},
+    ]
+    # alice watched 'Dune' once, 'Inception' once; bob watched nothing matching
+    history_by_user = {
+        '1': [
+            {'date': now - 100, 'media_type': 'movie', 'title': 'Dune'},
+            {'date': now - 200, 'media_type': 'movie', 'title': 'Inception'},
+        ],
+        '2': [
+            {'date': now - 100, 'media_type': 'movie', 'title': 'Inception'},
+        ],
+    }
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return _make_users_response(users)
+        if cmd == 'get_history':
+            uid = str(params.get('user_id', ''))
+            rows = history_by_user.get(uid, [])
+            return _make_history_response(rows)
+        return None
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    assert result == {'alice': 1}
+
+
+def test_get_all_watchers_movie_case_insensitive(monkeypatch):
+    """Title matching is case-insensitive."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    history = [{'date': now - 100, 'media_type': 'movie', 'title': 'DUNE'}]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('dune', days=7)
+    assert result == {'alice': 1}
+
+
+def test_get_all_watchers_tv_season_match(monkeypatch):
+    """Counts distinct episodes per user for the correct show + season."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [
+        {'user_id': '1', 'friendly_name': 'alice'},
+        {'user_id': '2', 'friendly_name': 'bob'},
+    ]
+    history_by_user = {
+        # alice: 3 distinct S1 episodes + 1 S2 episode (should not count)
+        '1': [
+            {'date': now - 10, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+            {'date': now - 20, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 2},
+            {'date': now - 30, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 3},
+            {'date': now - 40, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 2, 'media_index': 1},
+        ],
+        # bob: watched a different show, should not appear
+        '2': [
+            {'date': now - 10, 'media_type': 'episode', 'grandparent_title': 'Severance', 'parent_media_index': 1, 'media_index': 1},
+        ],
+    }
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        uid = str(params.get('user_id', ''))
+        return {'data': history_by_user.get(uid, [])}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Bluey', season_number=1, days=7)
+    assert result == {'alice': 3}
+
+
+def test_get_all_watchers_tv_season_filtering(monkeypatch):
+    """Season filtering excludes episodes from other seasons."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    # Only S2 episodes — should be excluded when querying for S1
+    history = [
+        {'date': now - 10, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 2, 'media_index': 1},
+        {'date': now - 20, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 2, 'media_index': 2},
+    ]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Bluey', season_number=1, days=7)
+    assert result == {}
+
+
+def test_get_all_watchers_cutoff_filters_old_rows(monkeypatch):
+    """Rows older than the days cutoff are excluded from the count."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    # One recent row, one beyond the 7-day cutoff
+    history = [
+        {'date': now - 100, 'media_type': 'movie', 'title': 'Dune'},
+        {'date': now - 10 * 24 * 3600, 'media_type': 'movie', 'title': 'Dune'},
+    ]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    # Only the recent watch should count; 'movie' de-duplication tracks 'movie'
+    # sentinel so the count is 1 regardless of how many recent rows match.
+    assert result == {'alice': 1}
+
+
+def test_get_all_watchers_pagination_fetches_multiple_pages(monkeypatch):
+    """Pagination continues until a page shorter than page_len is returned."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+
+    # Simulate two full pages (500 rows each) and one partial page
+    page_len = 500
+    full_page_movies = [
+        {'date': now - 10, 'media_type': 'movie', 'title': 'Dune'}
+        for _ in range(page_len)
+    ]
+    partial_page = [
+        {'date': now - 20, 'media_type': 'movie', 'title': 'Dune'}
+        for _ in range(3)
+    ]
+
+    call_log: list[int] = []
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        start = params.get('start', 0)
+        call_log.append(start)
+        if start == 0:
+            return {'data': full_page_movies}
+        if start == page_len:
+            return {'data': partial_page}
+        return {'data': []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    # Movie de-duplication: 'movie' sentinel used, so count is 1
+    assert result == {'alice': 1}
+    # Verify pagination: pages at start=0 and start=500 were fetched
+    assert 0 in call_log
+    assert page_len in call_log
+    # No third page should be requested after a partial page
+    assert page_len * 2 not in call_log
+
+
+def test_get_all_watchers_pagination_stops_on_empty_page(monkeypatch):
+    """Pagination stops when a page returns no rows."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    page_len = 500
+    full_page = [
+        {'date': now - 10, 'media_type': 'movie', 'title': 'Dune'}
+        for _ in range(page_len)
+    ]
+
+    call_count = {'n': 0}
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        call_count['n'] += 1
+        start = params.get('start', 0)
+        if start == 0:
+            return {'data': full_page}
+        return {'data': []}  # empty page stops pagination
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    assert result == {'alice': 1}
+    # Should have fetched page at start=0 and stopped after the empty page
+    assert call_count['n'] == 2
+
+
+def test_get_all_watchers_returns_empty_on_no_matches(monkeypatch):
+    """Returns empty dict when no history rows match the title."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    history = [{'date': now - 10, 'media_type': 'movie', 'title': 'Inception'}]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    assert result == {}
+
+
+def test_get_all_watchers_multiple_users(monkeypatch):
+    """Counts are aggregated independently per user."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [
+        {'user_id': '1', 'friendly_name': 'alice'},
+        {'user_id': '2', 'friendly_name': 'bob'},
+    ]
+    history_by_user = {
+        '1': [
+            {'date': now - 10, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+            {'date': now - 20, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 2},
+        ],
+        '2': [
+            {'date': now - 15, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+        ],
+    }
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        uid = str(params.get('user_id', ''))
+        return {'data': history_by_user.get(uid, [])}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Bluey', season_number=1, days=7)
+    assert result == {'alice': 2, 'bob': 1}
+
+
+def test_get_all_watchers_episode_deduplication(monkeypatch):
+    """The same episode watched twice by the same user counts only once."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    history = [
+        {'date': now - 10, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+        {'date': now - 20, 'media_type': 'episode', 'grandparent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+    ]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Bluey', season_number=1, days=7)
+    assert result == {'alice': 1}
+
+
+def test_get_all_watchers_returns_empty_when_get_users_fails(monkeypatch):
+    """Returns {} gracefully when the get_users API call fails."""
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    def fake_call(cmd, **params):
+        return None  # simulate API failure
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Dune', days=7)
+    assert result == {}
+
+
+def test_get_all_watchers_tv_uses_grandparent_title_fallback(monkeypatch):
+    """Falls back to parent_title then title when grandparent_title is absent."""
+    now = int(time.time())
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_URL', 'http://tautulli')
+    monkeypatch.setattr(tautulli_usage.config, 'TAUTULLI_API_KEY', 'key')
+
+    users = [{'user_id': '1', 'friendly_name': 'alice'}]
+    # Row uses parent_title instead of grandparent_title
+    history = [
+        {'date': now - 10, 'media_type': 'episode', 'grandparent_title': '', 'parent_title': 'Bluey', 'parent_media_index': 1, 'media_index': 1},
+    ]
+
+    def fake_call(cmd, **params):
+        if cmd == 'get_users':
+            return users
+        return {'data': history if params.get('user_id') == '1' else []}
+
+    monkeypatch.setattr(tautulli_usage, '_call_tautulli', fake_call)
+
+    result = tautulli_usage.get_all_watchers_for_title('Bluey', season_number=1, days=7)
+    assert result == {'alice': 1}


### PR DESCRIPTION
## Summary

Adds an automated watch-based cleanup system that tracks every movie and TV season requested through the bot, checks Tautulli watch history on a schedule, and removes content that has gone unwatched past a configurable window. Also warns users at download time if they have a backlog of unwatched content from earlier requests.

## Changes

### New files
- **`cleanup.py`** — `CleanupDB` backed by SQLite with WAL mode for safe cross-container concurrent access. Manages `cleanup_tracking` and `deletion_notifications` tables.
- **`cleanup_service.py`** — Standalone APScheduler sidecar that runs daily, evaluates age and Tautulli watch counts, unmonitors and deletes content past policy thresholds, and queues in-bot deletion notices.

### Modified files
- **`tautulli_usage.py`** — `get_all_watchers_for_title()` with paginated history fetch (`while True` + `start`/`length`) to avoid false positives from the 500-row cap.
- **`llm.py`** — `_backlog_warning()` helper + `CleanupDB.record_addition()` on all movie/series success paths. Backlog warning prepended to response when applicable.
- **`main.py`** — Pending deletion notifications delivered to user on next chat response.
- **`cleanup_service.py`** — Calls `sonarr.unmonitor_season()` before deleting episode files to prevent Sonarr from immediately re-downloading cleaned content.
- **`docker-compose.dev.yml` / `docker-compose.prod.yml`** — `media-bot-cleanup` sidecar container added to both stacks.
- **`requirements.txt`** — `apscheduler>=3.10,<4` added.
- **`config.py`**, **`.env.example`**, **`README.md`** — Six new `CLEANUP_*` env vars documented.

## Activation

```env
CLEANUP_ENABLED=true
```

All other vars have safe defaults. Feature is off until `CLEANUP_ENABLED=true` is set.

## ⚠️ Deployment note

The `media-bot-cleanup` prod sidecar requires a new image build before it can be deployed — `apscheduler` must be baked into the image. Do not apply `docker-compose.prod.yml` against an old image tag or the sidecar will crash with `ModuleNotFoundError`.