### PR TITLE
Fix Radarr movie lookup for conversational year phrasing

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -544,6 +544,49 @@ def _do_add_radarr_movie(radarr: "RadarrAPI", selected_movie: dict, is_kids: boo
     return f"Failed to add movie '{selected_movie['title']}': {error}"
 
 
+def _movie_lookup_terms(title: str) -> list[str]:
+    """Build ordered fallback search terms for Radarr movie lookups."""
+    raw = (title or "").strip()
+    if not raw:
+        return []
+
+    terms: list[str] = []
+
+    def _add(term: str):
+        candidate = (term or "").strip().rstrip('?.! ')
+        if candidate and all(candidate.casefold() != existing.casefold() for existing in terms):
+            terms.append(candidate)
+
+    _add(raw)
+
+    normalized = re.sub(
+        r'^(the\s+)?(movie|film|show|tv show|tv series|series)\s+',
+        '',
+        raw,
+        flags=re.IGNORECASE,
+    ).strip()
+    _add(normalized)
+
+    trimmed = normalized
+    trimmed = re.sub(r'\b(from|in)\s+this\s+year\b', '', trimmed, flags=re.IGNORECASE)
+    trimmed = re.sub(r'\b(this|current)\s+year\b', '', trimmed, flags=re.IGNORECASE)
+    trimmed = re.sub(r'\b(from|in)\s+(last|previous)\s+year\b', '', trimmed, flags=re.IGNORECASE)
+    trimmed = re.sub(r'\s{2,}', ' ', trimmed).strip()
+    _add(trimmed)
+
+    for quoted in re.findall(r'["\']([^"\']{2,})["\']', raw):
+        quoted_clean = quoted.strip().rstrip('?.! ')
+        quoted_clean = re.sub(
+            r'^(the\s+)?(movie|film|show|tv show|tv series|series)\s+',
+            '',
+            quoted_clean,
+            flags=re.IGNORECASE,
+        ).strip()
+        _add(quoted_clean)
+
+    return terms
+
+
 def add_radarr_movie_handler(
     title: str,
     state: dict = None,
@@ -565,7 +608,14 @@ def add_radarr_movie_handler(
 
     initial_kids_preference = _initial_kids_preference(title, is_kids)
     radarr = RadarrAPI()
-    movies = radarr.lookup_movie(title)
+    movies = []
+    lookup_term = title
+    for term in _movie_lookup_terms(title):
+        result = radarr.lookup_movie(term)
+        if result:
+            movies = result
+            lookup_term = term
+            break
     if not movies:
         return f"Could not find any movies matching '{title}'."
 
@@ -574,6 +624,14 @@ def add_radarr_movie_handler(
         selected_movie = next((m for m in movies if m.get('tmdbId') == preferred_tmdb_id), None)
     elif preferred_year is not None:
         selected_movie = next((m for m in movies if m.get('year') == preferred_year), None)
+
+    if selected_movie is None and lookup_term:
+        exact_title_matches = [
+            m for m in movies
+            if str(m.get('title', '')).strip().casefold() == lookup_term.strip().casefold()
+        ]
+        if len(exact_title_matches) == 1:
+            selected_movie = exact_title_matches[0]
 
     if selected_movie is None and len(movies) > 1 and preferred_tmdb_id is None:
         options = movies[:10]

--- a/llm.py
+++ b/llm.py
@@ -626,13 +626,17 @@ def add_radarr_movie_handler(
         selected_movie = next((m for m in movies if m.get('year') == preferred_year), None)
 
     if selected_movie is None and lookup_term:
+        comparison_terms = _movie_lookup_terms(lookup_term)
         exact_title_matches = [
-            m for m in movies
-            if str(m.get('title', '')).strip().casefold() == lookup_term.strip().casefold()
+            m
+            for m in movies
+            if any(
+                str(m.get('title', '')).strip().casefold() == t.strip().casefold()
+                for t in comparison_terms
+            )
         ]
         if len(exact_title_matches) == 1:
             selected_movie = exact_title_matches[0]
-
     if selected_movie is None and len(movies) > 1 and preferred_tmdb_id is None:
         options = movies[:10]
         if state is not None:

--- a/tests/test_llm_sanitize.py
+++ b/tests/test_llm_sanitize.py
@@ -192,3 +192,48 @@ def test_rule_based_route_handles_title_plus_download_status_query(monkeypatch):
 
     assert result == expected
     assert telemetry["heuristic_route"] == "check_download_status"
+
+
+def test_add_radarr_movie_handler_retries_with_trimmed_year_phrase(monkeypatch):
+    class FakeRadarr:
+        def __init__(self):
+            self.calls = []
+
+        def lookup_movie(self, term):
+            self.calls.append(term)
+            if term == "the invite":
+                return [{"title": "The Invite", "year": 2026, "tmdbId": 101}]
+            return []
+
+    fake_radarr = FakeRadarr()
+
+    monkeypatch.setattr(llm, "RadarrAPI", lambda: fake_radarr)
+    monkeypatch.setattr(llm, "_check_disk_space", lambda: (True, ""))
+    monkeypatch.setattr(llm.quota, "check_quota", lambda *_args, **_kwargs: (True, ""))
+    monkeypatch.setattr(llm, "_user_identity", lambda _ui: ("u1", "alice"))
+    monkeypatch.setattr(llm, "_backlog_warning", lambda _uid: None)
+    monkeypatch.setattr(llm, "_initial_kids_preference", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(llm, "_resolve_kids_classification", lambda **_kwargs: False)
+    monkeypatch.setattr(llm, "_do_add_radarr_movie", lambda *_args, **_kwargs: (True, "added"))
+
+    result = llm.add_radarr_movie_handler("the invite from this year")
+
+    assert result == "added"
+    assert fake_radarr.calls == ["the invite from this year", "the invite"]
+
+
+def test_add_radarr_movie_handler_not_found_uses_original_query_in_message(monkeypatch):
+    class FakeRadarr:
+        def lookup_movie(self, _term):
+            return []
+
+    monkeypatch.setattr(llm, "RadarrAPI", lambda: FakeRadarr())
+    monkeypatch.setattr(llm, "_check_disk_space", lambda: (True, ""))
+    monkeypatch.setattr(llm.quota, "check_quota", lambda *_args, **_kwargs: (True, ""))
+    monkeypatch.setattr(llm, "_user_identity", lambda _ui: ("u1", "alice"))
+    monkeypatch.setattr(llm, "_backlog_warning", lambda _uid: None)
+    monkeypatch.setattr(llm, "_initial_kids_preference", lambda *_args, **_kwargs: False)
+
+    result = llm.add_radarr_movie_handler("the invite from this year")
+
+    assert result == "Could not find any movies matching 'the invite from this year'."


### PR DESCRIPTION
## Summary
- add fallback lookup terms for movie requests that include conversational qualifiers like "from this year"
- retry Radarr lookup with normalized terms when the initial lookup returns no matches
- prefer a single exact title match before prompting the user to disambiguate
- add regression tests for the issue-reported phrasing

## Testing
- `python -m pytest tests/test_llm_sanitize.py -q`

Closes #84